### PR TITLE
Fix a sneak bug when using more than one sling at a time

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -17,7 +17,7 @@ throwing.register_bow("sling:sling", {
     end
   end,
   spawn_arrow_entity = function(pos, arrow, player)
-    local obj = minetest.add_entity(pos, "sling:sling_entity")
+    local obj = minetest.add_entity(pos, "sling:sling_entity", tostring(sling_sneak))
     obj:set_properties{
       textures = {arrow},
     }
@@ -32,8 +32,11 @@ minetest.register_entity("sling:sling_entity", throwing.make_arrow_def{
   target = throwing.target_node,
   on_hit_sound = "",
   on_throw_sound = "",
+  on_activate = function(self, staticdata)
+          self.sneak = staticdata == "true"
+  end,
   on_hit = function(self, pos, last_pos, node, object, hitter, data)
-    if sling_sneak == true then
+    if self.sneak then
       data.itemstack:set_count(1)
     end
     minetest.spawn_item(


### PR DESCRIPTION
The issue was that the `sling_sneak` variable can be modified by another shot before the arrow hits its target, especially in multiplayer. This PR makes this variable to be transferred to the entity as staticdata. The variable is still used between `allow_shot` and `spawn_arrow_entity`, but this is OK, since they are internally called by throwing by the same function, and Minetest won't run another Lua function until the one currently running actually returned.